### PR TITLE
Fix tbl_contains call for nvim < 0.10

### DIFF
--- a/lua/nvim-projects/init.lua
+++ b/lua/nvim-projects/init.lua
@@ -196,9 +196,7 @@ function M.gather_projects()
     })
 
     -- If this path contains a ".git" folder or file, it's a project
-    if vim.tbl_contains(entries, function(entry)
-          return entry:sub(-5) == "/.git"
-        end, { predicate = true }) then
+    if vim.tbl_contains(entries, path .. "/.git") then
       local name = vim.fn.fnamemodify(path, ":~:")
       add_project(name, path)
       return


### PR DESCRIPTION
`vim.tbl_contains` in nvim v0.9.4 doesn't support the predicate option